### PR TITLE
Pass along adapter version number in bid requests

### DIFF
--- a/conversant-htb.js
+++ b/conversant-htb.js
@@ -142,7 +142,7 @@ function ConversantHtb(configs) {
     		imp.id = parcel.requestId;
     		imp.secure = secure;
     		imp.displaymanager = '40834-index-client';
-    		imp.displaymanagerver = '0.0.1';
+    		imp.displaymanagerver = __profile.version;
 
     		if (xSlot.hasOwnProperty('bidfloor')) {
     			imp.bidfloor = xSlot.bidfloor;

--- a/spec/generateRequestObj.spec.js
+++ b/spec/generateRequestObj.spec.js
@@ -265,6 +265,9 @@ describe('generateRequestObj', function () {
         		if (typeof xSlot.bidfloor != 'undefined') {
         			expect(bid.bidfloor).to.equal(xSlot.bidfloor);
         		}
+        		// verify correct identification of index adapter
+        		expect(bid.displaymanager).to.equal('40834-index-client');
+        		expect(bid.displaymanagerver).to.equal(partnerModule.profile.version);
         	}
         });
         
@@ -276,7 +279,8 @@ describe('generateRequestObj', function () {
         it('check gdpr', function() {
         	expect(requestObject.data).to.have.deep.property('user', {ext: {consent: 'BOQ7WlgOQ7WlgABABwAAABJOACgACAAQABA'}});
         	expect(requestObject.data).to.have.deep.property('regs', {ext: {gdpr: 1}});
-        })
+        });
+        
         /* -----------------------------------------------------------------------*/
 
     /* ---------- IF MRA, generate a single request for all the parcels ---------- */


### PR DESCRIPTION
This is a small change to pass along the adapter's version number in the bid requests to facilitate problem identification.  Thanks.